### PR TITLE
Avoid index out of range issue

### DIFF
--- a/Sources/TortoiseCharmer.swift
+++ b/Sources/TortoiseCharmer.swift
@@ -39,11 +39,24 @@ class TortoiseCharmer {
             states[index].canvasSize = context.size
         }
 
+        // Make a copy of the array of commands for each Tortoise
+        var commandsToRun = [ Int: [Command] ]()
+        for (index, tortoise) in tortoises.enumerated() {
+            commandsToRun[index] = tortoise.commands
+        }
+
+        // Now iterate over all the commands in the command history and run
+        // using the copy of commands for each tortoise (saved a moment ago)
         for (index, history) in commandHistories.enumerated() where index <= toIndex {
-            states[history.tortoiseTag] =
-                tortoises[history.tortoiseTag]
-                    .commands[history.commandIndex]
+
+            // Get commands out of the dictionary for the current tortoise
+            if let commands = commandsToRun[history.tortoiseTag] {
+
+                // Actually run the command at the given index
+                states[history.tortoiseTag] = commands[history.commandIndex]
                     .exexute(in: states[history.tortoiseTag], with: context.cgContext)
+
+            }
         }
 
         for index in 0..<tortoises.count {

--- a/Sources/TortoiseCharmer.swift
+++ b/Sources/TortoiseCharmer.swift
@@ -4,8 +4,9 @@ class TortoiseCharmer {
 
     private(set) var tortoises: [Tortoise] = []
     private(set) var commandHistories: [(tortoiseTag: Int, commandIndex: Int)] = []
-    private var priorCommandHistoriesCount: Int = 0
-    private var commandHistoriesUnchangedCount: Int = 0
+
+    // ⭐️ Add lock object.
+    private let lock = NSLock()
 
     var commandedHandler: ((TortoiseCharmer) -> Void)?
 
@@ -17,12 +18,13 @@ class TortoiseCharmer {
         assert(tortoiseCount > 0)
         tortoises = []
         commandHistories = []
-        priorCommandHistoriesCount = 0
-        commandHistoriesUnchangedCount = 0
         for index in 0..<tortoiseCount {
             let tortoise = Tortoise()
             tortoise.tag = index
             tortoise.commandedHandler = { [unowned self] (tortoise) in
+                // ⭐️ Lock while writing commandHistories.
+                defer { self.lock.unlock() }
+                self.lock.lock()
                 self.commandHistories.append((tortoiseTag: tortoise.tag,
                                               commandIndex: tortoise.commands.count - 1))
                 self.commandedHandler?(self)
@@ -33,6 +35,10 @@ class TortoiseCharmer {
 
     @discardableResult
     func charm(with context: GraphicsContext, toFrame index: Int?) -> Int {
+        // ⭐️ Lock while reading commandHistories.
+        defer { self.lock.unlock() }
+        self.lock.lock()
+
         let endIndex = commandHistories.count - 1
         let toIndex = min(max((index ?? endIndex), 0), endIndex)
 
@@ -43,58 +49,12 @@ class TortoiseCharmer {
             states[index].canvasSize = context.size
         }
 
-        // Has the main thread finished adding commands to the tortoises and history?
-        // In other words, have the Tortoise commands arrays stabilized?
-        // (Defining "stable" as this method being called five times with unchanged counts)
-        if priorCommandHistoriesCount == commandHistories.count {
-            if commandHistoriesUnchangedCount < 5 {
-                commandHistoriesUnchangedCount += 1
-            }
-        } else {
-            // Command histories count changed, reset counter
-            commandHistoriesUnchangedCount = 0
+        for (index, history) in commandHistories.enumerated() where index <= toIndex {
+            states[history.tortoiseTag] =
+                tortoises[history.tortoiseTag]
+                    .commands[history.commandIndex]
+                    .exexute(in: states[history.tortoiseTag], with: context.cgContext)
         }
-
-        // Commands arrays are not being changed by other thread, so we can use them directly
-        if commandHistoriesUnchangedCount == 5 {
-
-            // If so, we can safely use the commands array on each Tortoise instance
-            for (index, history) in commandHistories.enumerated() where index <= toIndex {
-                states[history.tortoiseTag] =
-                    tortoises[history.tortoiseTag]
-                        .commands[history.commandIndex]
-                        .exexute(in: states[history.tortoiseTag], with: context.cgContext)
-            }
-
-        } else {
-
-            // Commands arrays still being changed by other thread.
-            //
-            // So, make a local copy of the commands array for each Tortoise instance for use in this thread
-            // to avoid index out of range errors (when commands array on Tortoise instances are modified by
-            // the main thread)
-            var commandsToRun = [ Int: [Command] ]()
-            for (index, tortoise) in tortoises.enumerated() {
-                commandsToRun[index] = tortoise.commands
-            }
-
-            // Now iterate over all the commands in the command history and run
-            // using the copy of commands for each tortoise (saved a moment ago)
-            for (index, history) in commandHistories.enumerated() where index <= toIndex {
-
-                // Get commands out of the dictionary for the current tortoise
-                if let commands = commandsToRun[history.tortoiseTag] {
-
-                        // Actually run the command at the given index
-                        states[history.tortoiseTag] = commands[history.commandIndex]
-                            .exexute(in: states[history.tortoiseTag], with: context.cgContext)
-                }
-            }
-
-        }
-
-        // Save the count of command histories to refer to next time this method is called
-        priorCommandHistoriesCount = commandHistories.count
 
         for index in 0..<tortoises.count {
             let state = states[index]

--- a/Sources/TortoiseCharmer.swift
+++ b/Sources/TortoiseCharmer.swift
@@ -4,9 +4,8 @@ class TortoiseCharmer {
 
     private(set) var tortoises: [Tortoise] = []
     private(set) var commandHistories: [(tortoiseTag: Int, commandIndex: Int)] = []
-
-    // ⭐️ Add lock object.
-    private let lock = NSLock()
+    private var priorCommandHistoriesCount: Int = 0
+    private var commandHistoriesUnchangedCount: Int = 0
 
     var commandedHandler: ((TortoiseCharmer) -> Void)?
 
@@ -18,13 +17,12 @@ class TortoiseCharmer {
         assert(tortoiseCount > 0)
         tortoises = []
         commandHistories = []
+        priorCommandHistoriesCount = 0
+        commandHistoriesUnchangedCount = 0
         for index in 0..<tortoiseCount {
             let tortoise = Tortoise()
             tortoise.tag = index
             tortoise.commandedHandler = { [unowned self] (tortoise) in
-                // ⭐️ Lock while writing commandHistories.
-                defer { self.lock.unlock() }
-                self.lock.lock()
                 self.commandHistories.append((tortoiseTag: tortoise.tag,
                                               commandIndex: tortoise.commands.count - 1))
                 self.commandedHandler?(self)
@@ -35,10 +33,6 @@ class TortoiseCharmer {
 
     @discardableResult
     func charm(with context: GraphicsContext, toFrame index: Int?) -> Int {
-        // ⭐️ Lock while reading commandHistories.
-        defer { self.lock.unlock() }
-        self.lock.lock()
-
         let endIndex = commandHistories.count - 1
         let toIndex = min(max((index ?? endIndex), 0), endIndex)
 
@@ -49,12 +43,58 @@ class TortoiseCharmer {
             states[index].canvasSize = context.size
         }
 
-        for (index, history) in commandHistories.enumerated() where index <= toIndex {
-            states[history.tortoiseTag] =
-                tortoises[history.tortoiseTag]
-                    .commands[history.commandIndex]
-                    .exexute(in: states[history.tortoiseTag], with: context.cgContext)
+        // Has the main thread finished adding commands to the tortoises and history?
+        // In other words, have the Tortoise commands arrays stabilized?
+        // (Defining "stable" as this method being called five times with unchanged counts)
+        if priorCommandHistoriesCount == commandHistories.count {
+            if commandHistoriesUnchangedCount < 5 {
+                commandHistoriesUnchangedCount += 1
+            }
+        } else {
+            // Command histories count changed, reset counter
+            commandHistoriesUnchangedCount = 0
         }
+
+        // Commands arrays are not being changed by other thread, so we can use them directly
+        if commandHistoriesUnchangedCount == 5 {
+
+            // If so, we can safely use the commands array on each Tortoise instance
+            for (index, history) in commandHistories.enumerated() where index <= toIndex {
+                states[history.tortoiseTag] =
+                    tortoises[history.tortoiseTag]
+                        .commands[history.commandIndex]
+                        .exexute(in: states[history.tortoiseTag], with: context.cgContext)
+            }
+
+        } else {
+
+            // Commands arrays still being changed by other thread.
+            //
+            // So, make a local copy of the commands array for each Tortoise instance for use in this thread
+            // to avoid index out of range errors (when commands array on Tortoise instances are modified by
+            // the main thread)
+            var commandsToRun = [ Int: [Command] ]()
+            for (index, tortoise) in tortoises.enumerated() {
+                commandsToRun[index] = tortoise.commands
+            }
+
+            // Now iterate over all the commands in the command history and run
+            // using the copy of commands for each tortoise (saved a moment ago)
+            for (index, history) in commandHistories.enumerated() where index <= toIndex {
+
+                // Get commands out of the dictionary for the current tortoise
+                if let commands = commandsToRun[history.tortoiseTag] {
+
+                        // Actually run the command at the given index
+                        states[history.tortoiseTag] = commands[history.commandIndex]
+                            .exexute(in: states[history.tortoiseTag], with: context.cgContext)
+                }
+            }
+
+        }
+
+        // Save the count of command histories to refer to next time this method is called
+        priorCommandHistoriesCount = commandHistories.count
 
         for index in 0..<tortoises.count {
             let state = states[index]

--- a/Sources/TortoiseCharmer.swift
+++ b/Sources/TortoiseCharmer.swift
@@ -5,6 +5,9 @@ class TortoiseCharmer {
     private(set) var tortoises: [Tortoise] = []
     private(set) var commandHistories: [(tortoiseTag: Int, commandIndex: Int)] = []
 
+    // ⭐️ Add lock object.
+    private let lock = NSLock()
+
     var commandedHandler: ((TortoiseCharmer) -> Void)?
 
     init(tortoiseCount: Int = 1) {
@@ -19,6 +22,9 @@ class TortoiseCharmer {
             let tortoise = Tortoise()
             tortoise.tag = index
             tortoise.commandedHandler = { [unowned self] (tortoise) in
+                // ⭐️ Lock while writing commandHistories.
+                defer { self.lock.unlock() }
+                self.lock.lock()
                 self.commandHistories.append((tortoiseTag: tortoise.tag,
                                               commandIndex: tortoise.commands.count - 1))
                 self.commandedHandler?(self)
@@ -29,6 +35,10 @@ class TortoiseCharmer {
 
     @discardableResult
     func charm(with context: GraphicsContext, toFrame index: Int?) -> Int {
+        // ⭐️ Lock while reading commandHistories.
+        defer { self.lock.unlock() }
+        self.lock.lock()
+
         let endIndex = commandHistories.count - 1
         let toIndex = min(max((index ?? endIndex), 0), endIndex)
 
@@ -39,24 +49,11 @@ class TortoiseCharmer {
             states[index].canvasSize = context.size
         }
 
-        // Make a copy of the array of commands for each Tortoise
-        var commandsToRun = [ Int: [Command] ]()
-        for (index, tortoise) in tortoises.enumerated() {
-            commandsToRun[index] = tortoise.commands
-        }
-
-        // Now iterate over all the commands in the command history and run
-        // using the copy of commands for each tortoise (saved a moment ago)
         for (index, history) in commandHistories.enumerated() where index <= toIndex {
-
-            // Get commands out of the dictionary for the current tortoise
-            if let commands = commandsToRun[history.tortoiseTag] {
-
-                // Actually run the command at the given index
-                states[history.tortoiseTag] = commands[history.commandIndex]
+            states[history.tortoiseTag] =
+                tortoises[history.tortoiseTag]
+                    .commands[history.commandIndex]
                     .exexute(in: states[history.tortoiseTag], with: context.cgContext)
-
-            }
         }
 
         for index in 0..<tortoises.count {

--- a/Sources/TortoiseCharmer.swift
+++ b/Sources/TortoiseCharmer.swift
@@ -5,9 +5,6 @@ class TortoiseCharmer {
     private(set) var tortoises: [Tortoise] = []
     private(set) var commandHistories: [(tortoiseTag: Int, commandIndex: Int)] = []
 
-    // ⭐️ Add lock object.
-    private let lock = NSLock()
-
     var commandedHandler: ((TortoiseCharmer) -> Void)?
 
     init(tortoiseCount: Int = 1) {
@@ -22,9 +19,6 @@ class TortoiseCharmer {
             let tortoise = Tortoise()
             tortoise.tag = index
             tortoise.commandedHandler = { [unowned self] (tortoise) in
-                // ⭐️ Lock while writing commandHistories.
-                defer { self.lock.unlock() }
-                self.lock.lock()
                 self.commandHistories.append((tortoiseTag: tortoise.tag,
                                               commandIndex: tortoise.commands.count - 1))
                 self.commandedHandler?(self)
@@ -35,10 +29,6 @@ class TortoiseCharmer {
 
     @discardableResult
     func charm(with context: GraphicsContext, toFrame index: Int?) -> Int {
-        // ⭐️ Lock while reading commandHistories.
-        defer { self.lock.unlock() }
-        self.lock.lock()
-
         let endIndex = commandHistories.count - 1
         let toIndex = min(max((index ?? endIndex), 0), endIndex)
 
@@ -49,11 +39,24 @@ class TortoiseCharmer {
             states[index].canvasSize = context.size
         }
 
+        // Make a copy of the array of commands for each Tortoise
+        var commandsToRun = [ Int: [Command] ]()
+        for (index, tortoise) in tortoises.enumerated() {
+            commandsToRun[index] = tortoise.commands
+        }
+
+        // Now iterate over all the commands in the command history and run
+        // using the copy of commands for each tortoise (saved a moment ago)
         for (index, history) in commandHistories.enumerated() where index <= toIndex {
-            states[history.tortoiseTag] =
-                tortoises[history.tortoiseTag]
-                    .commands[history.commandIndex]
+
+            // Get commands out of the dictionary for the current tortoise
+            if let commands = commandsToRun[history.tortoiseTag] {
+
+                // Actually run the command at the given index
+                states[history.tortoiseTag] = commands[history.commandIndex]
                     .exexute(in: states[history.tortoiseTag], with: context.cgContext)
+
+            }
         }
 
         for index in 0..<tortoises.count {


### PR DESCRIPTION
When a lot of commands are added in a short period of time, and we are animating the drawing, TortoiseCharmer seems to get tripped up on the contents of the commands array of a Tortoise instance.

Specifically, the Tortoise.commands array seems to change size while TortoiseCharmer.charm is trying to do it's thing, which causes an index out of range error.

![screen shot 2018-11-09 at 5 06 10 pm](https://user-images.githubusercontent.com/32135742/48291440-77959180-e444-11e8-9448-ed7666e8c774.png)

The commit in this pull request contains the bare minimum code that I came up with to fix, or at least work around, the issue.

The issue can be reproduced by modifying the single tortoise playground like this:

![screen shot 2018-11-09 at 5 24 56 pm](https://user-images.githubusercontent.com/32135742/48291419-62b8fe00-e444-11e8-9caa-9942cc941a8b.png)

In this commit on another branch of my TortoiseGraphics fork, I spent time digging in to this:

https://github.com/lcs-rgordon/TortoiseGraphics/commit/8bbe04329813f54428d3e11bd52354cff2f00102

1. In that branch I've created a macOS app and used the PlaygroundCanvas class to view the animation so that the full debugger can be used to inspect the index out of range error.

2. I've included code that reliably triggers the index out of range error (similar to a recent assignment I gave my students).